### PR TITLE
Add simple shopping cart

### DIFF
--- a/src/eShopOnBlazor/Models/CartItem.cs
+++ b/src/eShopOnBlazor/Models/CartItem.cs
@@ -1,0 +1,8 @@
+
+namespace eShopOnBlazor.Models;
+
+public class CartItem
+{
+    public CatalogItem Item { get; set; } = default!;
+    public int Quantity { get; set; }
+}

--- a/src/eShopOnBlazor/Pages/Cart.razor
+++ b/src/eShopOnBlazor/Pages/Cart.razor
@@ -1,0 +1,32 @@
+@using System.Linq
+@page "/cart"
+@inject CartService CartService
+
+<h2 class="esh-body-title">Shopping Cart</h2>
+
+@if (!CartService.Items.Any())
+{
+    <p>Your cart is empty.</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Product</th>
+                <th>Quantity</th>
+                <th>Price</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var cartItem in CartService.Items)
+            {
+                <tr>
+                    <td>@cartItem.Item.Name</td>
+                    <td>@cartItem.Quantity</td>
+                    <td>@cartItem.Item.Price.ToString("C")</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}

--- a/src/eShopOnBlazor/Pages/Catalog/Details.razor
+++ b/src/eShopOnBlazor/Pages/Catalog/Details.razor
@@ -1,6 +1,7 @@
 ﻿@page "/Catalog/Details/{id:int}"
 @inject ICatalogService CatalogService
 @inject ILogger<Details> Logger
+@inject CartService CartService
 
 <h2 class="esh-body-title">Details</h2>
 
@@ -86,6 +87,7 @@
         </div>
 
         <div class="text-right esh-button-actions">
+            <button class="btn esh-button esh-button-primary" @onclick="() => AddToCart(_item)">Add to Cart</button>
 
             <a href="@($"/Catalog/Edit/{_item.Id}")" class="btn esh-button esh-button-primary">
                 Edit
@@ -119,4 +121,9 @@
 
         _item = CatalogService.FindCatalogItem(Id);
     }
+    void AddToCart(CatalogItem item)
+    {
+        CartService.AddItem(item);
+    }
+
 }

--- a/src/eShopOnBlazor/Pages/Index.razor
+++ b/src/eShopOnBlazor/Pages/Index.razor
@@ -1,5 +1,6 @@
 ﻿@page "/"
 @inject ICatalogService CatalogService
+@inject CartService CartService
 
 <div class="esh-table">
     <p class="esh-link-wrapper">
@@ -31,6 +32,7 @@
                     <th>Stock</th>
                     <th>Restock</th>
                     <th>Max stock</th>
+                    <th>Add</th>
                 </tr>
             </thead>
             <tbody>
@@ -66,6 +68,9 @@
                         </td>
                         <td>
                             <p>@catalogItem.MaxStockThreshold</p>
+                        </td>
+                        <td>
+                            <button class="btn btn-sm btn-primary" @onclick="() => AddToCart(catalogItem)">Add to Cart</button>
                         </td>
                         <td>
                             <a href="@($"/Catalog/Edit/{catalogItem.Id}")" class="esh-table-link">
@@ -127,6 +132,11 @@
     {
         pageIndex--;
         LoadPage();
+    }
+
+    void AddToCart(CatalogItem item)
+    {
+        CartService.AddItem(item);
     }
 
     void Next()

--- a/src/eShopOnBlazor/Program.cs
+++ b/src/eShopOnBlazor/Program.cs
@@ -12,6 +12,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorPages();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
+builder.Services.AddScoped<CartService>();
 if (builder.Configuration.GetValue<bool>("UseMockData"))
 {
     builder.Services.AddSingleton<ICatalogService, CatalogServiceMock>();

--- a/src/eShopOnBlazor/Services/CartService.cs
+++ b/src/eShopOnBlazor/Services/CartService.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using eShopOnBlazor.Models;
+
+namespace eShopOnBlazor.Services;
+
+public class CartService
+{
+    private readonly List<CartItem> _items = new();
+
+    public IReadOnlyList<CartItem> Items => _items;
+
+    public int TotalItems => _items.Sum(i => i.Quantity);
+
+    public void AddItem(CatalogItem item)
+    {
+        var existing = _items.FirstOrDefault(i => i.Item.Id == item.Id);
+        if (existing != null)
+        {
+            existing.Quantity++;
+        }
+        else
+        {
+            _items.Add(new CartItem { Item = item, Quantity = 1 });
+        }
+    }
+
+    public void RemoveItem(int itemId)
+    {
+        var existing = _items.FirstOrDefault(i => i.Item.Id == itemId);
+        if (existing != null)
+        {
+            existing.Quantity--;
+            if (existing.Quantity <= 0)
+            {
+                _items.Remove(existing);
+            }
+        }
+    }
+
+    public void Clear() => _items.Clear();
+}

--- a/src/eShopOnBlazor/Shared/MainLayout.razor
+++ b/src/eShopOnBlazor/Shared/MainLayout.razor
@@ -1,10 +1,14 @@
 ﻿@inherits LayoutComponentBase
+@inject CartService CartService
 
 <header class="navbar navbar-light navbar-static-top">
     <div class="esh-header-brand">
         <a href="">
             <img src="/images/brand.png" />
         </a>
+    </div>
+    <div class="ml-auto p-2">
+        <a href="cart">Cart (@CartService.TotalItems)</a>
     </div>
 </header>
 


### PR DESCRIPTION
## Summary
- introduce `CartItem` model and `CartService` for stateful cart
- show cart item count in main layout header
- allow adding catalog items to cart from list and details pages
- add `/cart` page to display current cart contents
- register `CartService` in dependency injection

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685083369d4c832ca2c614646107419f