### PR TITLE
Add simple order history tracking

### DIFF
--- a/src/eShopOnBlazor/Models/Order.cs
+++ b/src/eShopOnBlazor/Models/Order.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace eShopOnBlazor.Models;
+
+public class Order
+{
+    public int Id { get; set; }
+    public DateTime Created { get; set; }
+    public List<CartItem> Items { get; set; } = new();
+    public decimal TotalPrice => Items.Sum(i => i.Item.Price * i.Quantity);
+}

--- a/src/eShopOnBlazor/Pages/Cart.razor
+++ b/src/eShopOnBlazor/Pages/Cart.razor
@@ -1,6 +1,7 @@
 @using System.Linq
 @page "/cart"
 @inject CartService CartService
+@inject OrderService OrderService
 @inject IJSRuntime JS
 
 <h2 class="esh-body-title">Shopping Cart</h2>
@@ -40,6 +41,7 @@ else
 @code {
     async Task Checkout()
     {
+        OrderService.AddOrder(CartService.Items);
         await JS.InvokeVoidAsync("alert", "Order placed");
         CartService.Clear();
     }

--- a/src/eShopOnBlazor/Pages/Orders.razor
+++ b/src/eShopOnBlazor/Pages/Orders.razor
@@ -1,0 +1,32 @@
+@using System.Linq
+@page "/orders"
+@inject OrderService OrderService
+
+<h2 class="esh-body-title">Order History</h2>
+
+@if (!OrderService.Orders.Any())
+{
+    <p>No orders have been placed.</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Order #</th>
+                <th>Date</th>
+                <th>Total</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var order in OrderService.Orders)
+            {
+                <tr>
+                    <td>@order.Id</td>
+                    <td>@order.Created.ToString("g")</td>
+                    <td>@order.TotalPrice.ToString("C")</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}

--- a/src/eShopOnBlazor/Program.cs
+++ b/src/eShopOnBlazor/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddRazorPages();
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 
 builder.Services.AddScoped<CartService>();
+builder.Services.AddScoped<OrderService>();
 if (builder.Configuration.GetValue<bool>("UseMockData"))
 {
     builder.Services.AddSingleton<ICatalogService, CatalogServiceMock>();

--- a/src/eShopOnBlazor/Services/OrderService.cs
+++ b/src/eShopOnBlazor/Services/OrderService.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using eShopOnBlazor.Models;
+
+
+namespace eShopOnBlazor.Services;
+
+public class OrderService
+{
+    private readonly List<Order> _orders = new();
+    private int _nextId = 1;
+
+    public IReadOnlyList<Order> Orders => _orders;
+
+    public void AddOrder(IEnumerable<CartItem> items)
+    {
+        var order = new Order
+        {
+            Id = _nextId++,
+            Created = DateTime.Now,
+            Items = items.Select(i => new CartItem { Item = i.Item, Quantity = i.Quantity }).ToList()
+        };
+        _orders.Add(order);
+    }
+}

--- a/src/eShopOnBlazor/Shared/NavMenu.razor
+++ b/src/eShopOnBlazor/Shared/NavMenu.razor
@@ -22,6 +22,11 @@
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Fetch data
             </NavLink>
         </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="orders">
+                <span class="oi oi-tag" aria-hidden="true"></span> Orders
+            </NavLink>
+        </li>
     </ul>
 </div>
 


### PR DESCRIPTION
## Summary
- allow checkout to record an order using new `OrderService`
- show previous orders in a new Orders page
- add `Order` model to represent placed orders
- register the new service and link to the orders page from nav menu

## Testing
- `dotnet build src/eShopOnBlazor/eShopOnBlazor.csproj -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685090982d74832cbe9c26ec664bb1f5